### PR TITLE
fix: use the correct function and arguments for query args

### DIFF
--- a/src/Servant/PureScript/CodeGen.hs
+++ b/src/Servant/PureScript/CodeGen.hs
@@ -146,9 +146,9 @@ genBuildQuery args = softline <> "<> \"?\" <> " <> (docIntercalate (softline <> 
 
 genBuildQueryArg :: QueryArg PSType -> Doc
 genBuildQueryArg arg = case arg ^. queryArgType of
-    Normal -> genQueryEncoding "encodeQuery"
-    Flag   -> genQueryEncoding "encodeQuery"
-    List   -> genQueryEncoding "encodeListQuery"
+    Normal -> genQueryEncoding "encodeQueryItem spOpts_'"
+    Flag   -> genQueryEncoding "encodeQueryItem spOpts_'"
+    List   -> genQueryEncoding "encodeListQuery spOpts_'"
   where
     argText = arg ^. queryArgName ^. argName ^. to unPathSegment
     encodedArgName = strictText . textURLEncode True $ argText


### PR DESCRIPTION
When using the `Capture` combinator, the generated output was using a non existing function. With this patch, the output compiles, but I do not have an easy way to test it yet.

What do you think?
