### PR TITLE
use MonadAsk instead of MonadReader

### DIFF
--- a/examples/central-counter/frontend/src/Counter/WebAPI.purs
+++ b/examples/central-counter/frontend/src/Counter/WebAPI.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Error.Class (class MonadError)
-import Control.Monad.Reader.Class (ask, class MonadReader)
+import Control.Monad.Reader.Class (ask, class MonadAsk)
 import Counter.ServerTypes (AuthToken, CounterAction)
 import Data.Argonaut.Generic.Aeson (decodeJson, encodeJson)
 import Data.Argonaut.Printer (printJson)
@@ -23,7 +23,7 @@ newtype SPParams_ = SPParams_ { authToken :: AuthToken
                               }
 
 getCounter :: forall eff m.
-              (MonadReader (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)
+              (MonadAsk (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)
               => m Int
 getCounter = do
   spOpts_' <- ask
@@ -45,7 +45,7 @@ getCounter = do
   getResult affReq decodeJson affResp
   
 putCounter :: forall eff m.
-              (MonadReader (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)
+              (MonadAsk (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)
               => CounterAction -> m Int
 putCounter reqBody = do
   spOpts_' <- ask

--- a/examples/central-counter/frontend/src/Counter/WebAPI/MakeRequests.purs
+++ b/examples/central-counter/frontend/src/Counter/WebAPI/MakeRequests.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Error.Class (class MonadError)
-import Control.Monad.Reader.Class (ask, class MonadReader)
+import Control.Monad.Reader.Class (ask, class MonadAsk)
 import Counter.ServerTypes (AuthToken, CounterAction)
 import Counter.WebAPI (SPParams_(..))
 import Data.Argonaut.Generic.Aeson (decodeJson, encodeJson)
@@ -25,7 +25,7 @@ import Servant.Subscriber.Subscriptions (Subscriptions, makeSubscriptions)
 import Servant.Subscriber.Types (Path(..))
 import Servant.Subscriber.Util (TypedToUser, subGenFlagQuery, subGenListQuery, subGenNormalQuery, toUserType)
 
-getCounter :: forall m. MonadReader (SPSettings_ SPParams_) m => m HttpRequest
+getCounter :: forall m. MonadAsk (SPSettings_ SPParams_) m => m HttpRequest
 getCounter = do
   spOpts_' <- ask
   let spOpts_ = case spOpts_' of SPSettings_ o -> o
@@ -47,7 +47,7 @@ getCounter = do
                 }
   pure spReq
 
-putCounter :: forall m. MonadReader (SPSettings_ SPParams_) m => CounterAction
+putCounter :: forall m. MonadAsk (SPSettings_ SPParams_) m => CounterAction
               -> m HttpRequest
 putCounter reqBody = do
   spOpts_' <- ask

--- a/examples/central-counter/frontend/src/Counter/WebAPI/Subscriber.purs
+++ b/examples/central-counter/frontend/src/Counter/WebAPI/Subscriber.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Error.Class (class MonadError)
-import Control.Monad.Reader.Class (ask, class MonadReader)
+import Control.Monad.Reader.Class (ask, class MonadAsk)
 import Counter.ServerTypes (AuthToken)
 import Counter.WebAPI (SPParams_(..))
 import Data.Argonaut.Generic.Aeson (decodeJson, encodeJson)
@@ -27,7 +27,7 @@ import Servant.Subscriber.Util (TypedToUser, subGenFlagQuery, subGenListQuery, s
 
 import Counter.WebAPI.MakeRequests as MakeRequests
 
-getCounter :: forall m a. MonadReader (SPSettings_ SPParams_) m =>
+getCounter :: forall m a. MonadAsk (SPSettings_ SPParams_) m =>
               TypedToUser Int a -> m (Subscriptions a)
 getCounter spToUser_ = do
   spReq <- MakeRequests.getCounter 

--- a/src/Servant/PureScript/CodeGen.hs
+++ b/src/Servant/PureScript/CodeGen.hs
@@ -88,7 +88,7 @@ genGetReaderParams = stack . map (genGetReaderParam . psVar . _pName)
 
 
 genSignature :: Text -> [PSType] -> Maybe PSType -> Doc
-genSignature = genSignatureBuilder $ "forall eff m." <+/> "(MonadReader (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)" <+/> "=>"
+genSignature = genSignatureBuilder $ "forall eff m." <+/> "(MonadAsk (SPSettings_ SPParams_) m, MonadError AjaxError m, MonadAff ( ajax :: AJAX | eff) m)" <+/> "=>"
 
 genSignatureBuilder :: Doc -> Text -> [PSType] -> Maybe PSType -> Doc
 genSignatureBuilder constraint fnName params mRet = fName <+> "::" <+> align (constraint <+/> parameterString)

--- a/src/Servant/PureScript/Internal.hs
+++ b/src/Servant/PureScript/Internal.hs
@@ -17,10 +17,10 @@ import           Data.Bifunctor
 import           Data.Char
 import           Data.Monoid
 import           Data.Proxy
-import           Data.Set                            (Set)
-import qualified Data.Set                            as Set
-import           Data.Text                           (Text)
-import qualified Data.Text                           as T
+import           Data.Set                           (Set)
+import qualified Data.Set                           as Set
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
 import           Data.Typeable
 
 import           Language.PureScript.Bridge
@@ -73,7 +73,7 @@ makeLenses ''Param
 
 
 data Settings = Settings {
-  _apiModuleName   :: Text
+  _apiModuleName         :: Text
   -- | This function parameters should instead be put in a Reader monad.
   --
   --   'baseUrl' will be put there by default, you can add additional parameters.
@@ -81,8 +81,8 @@ data Settings = Settings {
   --   If your API uses a given parameter name multiple times with different types,
   --   only the ones matching the type of the first occurrence
   --   will be put in the Reader monad, all others will still be passed as function parameter.
-, _readerParams    :: Set ParamName
-, _standardImports :: ImportLines
+, _readerParams          :: Set ParamName
+, _standardImports       :: ImportLines
   -- | If you want codegen for servant-subscriber, set this to True. See the central-counter example
   --   for a simple usage case.
 , _generateSubscriberAPI :: Bool
@@ -94,7 +94,7 @@ defaultSettings = Settings {
     _apiModuleName    = "ServerAPI"
   , _readerParams     = Set.singleton baseURLId
   , _standardImports = importsFromList
-        [ ImportLine "Control.Monad.Reader.Class" (Set.fromList [ "class MonadReader", "ask" ])
+        [ ImportLine "Control.Monad.Reader.Class" (Set.fromList [ "class MonadAsk", "ask" ])
         , ImportLine "Control.Monad.Error.Class" (Set.fromList [ "class MonadError" ])
         , ImportLine "Control.Monad.Aff.Class" (Set.fromList [ "class MonadAff", "liftAff" ])
         , ImportLine "Network.HTTP.Affjax" (Set.fromList [ "AJAX" ])

--- a/src/Servant/PureScript/MakeRequests.hs
+++ b/src/Servant/PureScript/MakeRequests.hs
@@ -86,7 +86,7 @@ genFunction allRParams req = let
 
 
 genSignature :: Text -> [PSType] -> Maybe PSType -> Doc
-genSignature = genSignatureBuilder $ "forall m." <+/> "MonadReader (SPSettings_ SPParams_) m" <+/> "=>"
+genSignature = genSignatureBuilder $ "forall m." <+/> "MonadAsk (SPSettings_ SPParams_) m" <+/> "=>"
 
 genFnBody :: [PSParam] -> Req PSType -> Doc
 genFnBody rParams req = "do"

--- a/src/Servant/PureScript/Subscriber.hs
+++ b/src/Servant/PureScript/Subscriber.hs
@@ -22,10 +22,10 @@ import           Network.HTTP.Types.URI             (urlEncode)
 import           Servant.Foreign
 import           Servant.PureScript.CodeGen         (docIntercalate, genFnHead,
                                                      genModuleHeader,
+                                                     genSignatureBuilder,
                                                      getReaderParams, psVar,
                                                      reqToParams,
-                                                     reqsToImportLines,
-                                                     genSignatureBuilder)
+                                                     reqsToImportLines)
 import           Servant.PureScript.Internal
 import           Servant.PureScript.MakeRequests    hiding (genFnBody,
                                                      genFunction, genModule,
@@ -60,7 +60,7 @@ genFunction allRParams req = let
     fnName = req ^. reqFuncName ^. camelCaseL
     responseType = case req ^. reqReturnType of
                      Nothing -> psUnit
-                     Just t -> t
+                     Just t  -> t
     allParamsList = makeTypedToUserParam responseType : baseURLParam : reqToParams req
     fnParams = filter (not . flip Set.member rParamsSet) allParamsList -- Use list not set, as we don't want to change order of parameters
 
@@ -73,7 +73,7 @@ genFunction allRParams req = let
 
 
 genSignature :: Text -> [PSType] -> Maybe PSType -> Doc
-genSignature = genSignatureBuilder $ "forall m a." <+/> "MonadReader (SPSettings_ SPParams_) m" <+/> "=>"
+genSignature = genSignatureBuilder $ "forall m a." <+/> "MonadAsk (SPSettings_ SPParams_) m" <+/> "=>"
 
 genFnBody :: Text -> [Text] -> Doc
 genFnBody fName params = "do"


### PR DESCRIPTION
Since `local` is never used, we can use the weaker `MonadAsk`. This makes the generated code useful in more situations (e.g. halogen, where only `MonadAsk` is available).

Basically `s/MonadReader/MonadAsk/g` + some stylish-haskell changes.