### PR TITLE
Generated code uses encoders and decoders from provided options instead of hard-coded Aeson ones

### DIFF
--- a/src/Servant/PureScript/CodeGen.hs
+++ b/src/Servant/PureScript/CodeGen.hs
@@ -116,6 +116,9 @@ genFnBody rParams req = "do"
       </> genBuildQueryArgs (req ^. reqUrl ^. queryStr)
       </> hang 6 ("let reqUrl ="     <+> genBuildURL (req ^. reqUrl))
       </> "let reqHeaders =" </> indent 6 (req ^. reqHeaders ^. to genBuildHeaders)
+      </> case req ^. reqBody of
+             Nothing -> ""
+             Just _ -> "let encodeJson = case spOpts_.encodeJson of SPSettingsEncodeJson_ e -> e"
       </> "let affReq =" <+> hang 2 ( "defaultRequest" </>
             "{ method ="  <+> "httpMethod"
         </> ", url ="     <+> "reqUrl"
@@ -125,6 +128,7 @@ genFnBody rParams req = "do"
               Just _  -> ", content =" <+> "toNullable <<< Just <<< stringify <<< encodeJson $ reqBody" </> "}"
       )
       </> "affResp <- affjax affReq"
+      </> "let decodeJson = case spOpts_.decodeJson of SPSettingsDecodeJson_ d -> d"
       </> "getResult affReq decodeJson affResp"
     ) <> line
 

--- a/src/Servant/PureScript/Internal.hs
+++ b/src/Servant/PureScript/Internal.hs
@@ -101,10 +101,9 @@ defaultSettings = Settings {
         , ImportLine "Network.HTTP.Affjax" (Set.fromList [ "AJAX" ])
         , ImportLine "Data.Nullable" (Set.fromList [ "toNullable" ])
         , ImportLine "Servant.PureScript.Affjax" (Set.fromList [ "AjaxError", "defaultRequest", "affjax" ])
-        , ImportLine "Servant.PureScript.Settings" (Set.fromList [ "SPSettings_(..)", "gDefaultToURLPiece" ])
+        , ImportLine "Servant.PureScript.Settings" (Set.fromList [ "SPSettings_(..)", "SPSettingsDecodeJson_(..)", "SPSettingsEncodeJson_(..)", "gDefaultToURLPiece" ])
         , ImportLine "Servant.PureScript.Util" (Set.fromList [ "encodeListQuery", "encodeURLPiece", "encodeQueryItem", "getResult", "encodeHeader" ])
         , ImportLine "Prim" (Set.fromList [ "String" ]) -- For baseURL!
-        , ImportLine "Data.Argonaut.Generic.Aeson" (Set.fromList [ "encodeJson", "decodeJson" ]) -- Should not be necessary - compiler bug!
         , ImportLine "Data.Maybe" (Set.fromList [ "Maybe(..)"])
         , ImportLine "Data.String" (Set.fromList ["joinWith"])
         , ImportLine "Data.Array" (Set.fromList ["catMaybes", "null"])


### PR DESCRIPTION
Solves #6 

Accompanied by https://github.com/eskimor/purescript-servant-support/pull/10