### PR TITLE
Remove use of deprecated and removed Servant.Utils.Links

### DIFF
--- a/servant-purescript.cabal
+++ b/servant-purescript.cabal
@@ -35,7 +35,7 @@ library
                      , lens
                      , mainland-pretty
                      , purescript-bridge >= 0.6
-                     , servant
+                     , servant >= 0.14.1
                      , servant-foreign
                      , servant-server
                      , servant-subscriber

--- a/src/Servant/API/BrowserHeader.hs
+++ b/src/Servant/API/BrowserHeader.hs
@@ -13,7 +13,7 @@
 
 module Servant.API.BrowserHeader where
 
-import Servant.Utils.Links
+import Servant.Links
 import Servant
 import Servant.Foreign
 import Servant.Subscriber.Subscribable


### PR DESCRIPTION
Deprecated since servant 0.14.1, removed in 0.17.
See https://github.com/haskell-servant/servant/pull/998