### PR TITLE
GitHub actions and compilation fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+# modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml
+name: CI tests
+
+on:
+  push:
+    branches:
+    - '*'
+    paths-ignore: []
+  pull_request:
+    paths-ignore: []
+
+jobs:
+  linux:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        versions:
+          - ghc: '8.0.2'
+            cabal: '3.2'
+          - ghc: '8.2.2'
+            cabal: '3.2'
+          - ghc: '8.4.4'
+            cabal: '3.2'
+          - ghc: '8.6.5'
+            cabal: '3.2'
+          - ghc: '8.8.4'
+            cabal: '3.2'
+          - ghc: '8.10.3'
+            cabal: '3.2'
+    steps:
+    - uses: actions/checkout@v2
+
+    # need to install older cabal/ghc versions from ppa repository
+
+    - name: Install recent cabal/ghc
+      uses: actions/setup-haskell@v1.1.3
+      with:
+        ghc-version: ${{ matrix.versions.ghc }}
+        cabal-version: ${{ matrix.versions.cabal }}
+
+    # declare/restore cached things
+    # caching doesn't work for scheduled runs yet
+    # https://github.com/actions/cache/issues/63
+
+    - name: Cache cabal global package db
+      id:   cabal-global
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-${{ hashFiles('cabal.project') }}
+
+    - name: Cache cabal work
+      id:   cabal-local
+      uses: actions/cache@v2
+      with:
+        path: |
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-local
+
+    - name: Install dependencies
+      run: |
+          cabal update
+          cabal build --dependencies-only --enable-tests --disable-optimization
+    - name: Build
+      run: |
+          cabal build --enable-tests --disable-optimization 2>&1 | tee build.log
+    - name: Test
+      run: |
+          cabal test --disable-optimization

--- a/src/Servant/API/BrowserHeader.hs
+++ b/src/Servant/API/BrowserHeader.hs
@@ -34,7 +34,11 @@ instance HasLink sub => HasLink (BrowserHeader sym a :> sub) where
   toLink _ = toLink (Proxy :: Proxy (Header sym a :> sub))
 #endif
 
-instance (KnownSymbol sym, FromHttpApiData a, HasServer sublayout context)
+instance ( KnownSymbol sym
+         , FromHttpApiData a
+         , HasServer sublayout context
+         , HasContextEntry (context .++ DefaultErrorFormatters) ErrorFormatters
+         )
       => HasServer (BrowserHeader sym a :> sublayout) context where
 
   type ServerT (BrowserHeader sym a :> sublayout) m = ServerT (Header sym a :> sublayout) m


### PR DESCRIPTION
Github actions modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml

Seems to work: https://github.com/peterbecich/servant-purescript/actions/runs/492493731

The compilation errors with GHC 8.0 and 8.2 might be fixed with: https://github.com/eskimor/purescript-bridge/pull/50